### PR TITLE
Update README.md to include :no_entry: deprecated note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# CLOVER
+# :no_entry: DEPRECATED
+
+This is no longer supported as a newer version has been created and is maintained at [CLOVER-energy/CLOVER](https://github.com/CLOVER-energy/CLOVER). Please consider using this newer version instead :smiley:.
+
+[![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
+
+# CLOVER <former description>
+_Description applicable to versions up to, and including,_ `v4.0`
+
 CLOVER minigrid simulation and optimisation for supporting rural electrification in developing countries
 CLOVER Quick Start Guide
 


### PR DESCRIPTION
## Description
This pull request is being opened to apply a note to the top of the `README.md` file in the CLOVER `v4.0` repository to inform users that the version of CLOVER here is deprecated and that they should refer to the [CLOVER-energy/CLOVER](https://github.com/CLOVER-energy/CLOVER) repository for up-to-date versions from `v5.0` onwards 😄 